### PR TITLE
Delete Retired .openpublishing.build.ps1 script of branch live for archived repo

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -1,6 +1,7 @@
 {
   "docsets_to_publish": [],
   "notification_subscribers": [],
+  "sync_notification_subscribers": null,
   "branches_to_filter": [
     "live-sxs",
     "master-sxs"
@@ -13,7 +14,7 @@
     {
       "path_to_root": "_themes",
       "url": "https://github.com/Microsoft/templates.docs.msft.zh-cn",
-      "branch": "master",
+      "branch": "main",
       "branch_mapping": {}
     },
     {
@@ -22,7 +23,7 @@
       "branch": "live",
       "branch_mapping": {
         "live": "live",
-        "master": "master"
+        "main": "main"
       }
     }
   ],


### PR DESCRIPTION
Delete Retired .openpublishing.build.ps1 script of branch live for archived repo